### PR TITLE
Lineup VJ entries and OBS script update

### DIFF
--- a/Web Version/shizu-backend/src/schema.ts
+++ b/Web Version/shizu-backend/src/schema.ts
@@ -2,6 +2,7 @@ import { buildSchema } from "graphql";
 
 export const SCHEMA = buildSchema(`
 type Query {
+    test(mandatory: String!, optional: String): String
     getLedger: ledgerObject
     getLineup(name: String!): lineupObject
     getAppThemes: [themeObject]
@@ -23,7 +24,7 @@ type Mutation {
     updatePromo(index: Int!, name: String, path: String): ledgerObject
     createLineup(name: String!): String
     updateLineup(name: String!, djs: [lineupDjObjectInput], promos: [String]): String
-    setLineupDjLive(lineup_name: String!, dj_name: String!, is_live: Boolean!): String
+    setLineupDjLive(lineup_name: String!, dj_name: String!, is_live: Boolean, vj: String): String
     swapLineupDJs(lineup_name: String!, index_a: Int!, index_b: Int!): String
     swapLineupPromos(lineup_name: String!, index_a: Int!, index_b: Int!): String
     addDjToLineup(lineup_name: String!, dj_name: String!): String
@@ -61,7 +62,8 @@ type promoObject {
 },
 type lineupDjObject {
     name: String,
-    is_live: Boolean
+    is_live: Boolean,
+    vj: String
 },
 type themeObject {
     title: String,

--- a/Web Version/shizu-backend/src/server.ts
+++ b/Web Version/shizu-backend/src/server.ts
@@ -1,4 +1,4 @@
-import { createHandler } from 'graphql-http/lib/use/express';
+import { createHandler } from "graphql-http/lib/use/express";
 import { SCHEMA } from "./schema";
 import {
   getLedger,

--- a/Web Version/shizu-backend/src/types.ts
+++ b/Web Version/shizu-backend/src/types.ts
@@ -6,15 +6,18 @@ export interface IDj {
   stream_key?: string;
   last_live_resolution?: number[];
 }
+
 export interface ILineupDj {
   name: string;
   is_live: boolean;
   url?: string;
   recording_path?: string;
+  vj?: string;
 }
+
 export interface IPromo {
   name: string;
-  path: string;
+  path?: string;
 }
 
 export interface ILedger {
@@ -88,6 +91,7 @@ export interface IExportDjineupData {
   recording_path: string;
   resolution: Promise<number[] | Error>;
   url: string;
+  vj: string;
 }
 
 export interface IExportPromoLineupData {

--- a/Web Version/shizu-frontend/src/lib/store.js
+++ b/Web Version/shizu-frontend/src/lib/store.js
@@ -291,7 +291,7 @@ mutation {
 const getLineup = (name) => `
 query {
     getLineup(name: "${name}") {
-        djs {name, is_live}
+        djs {name, is_live, vj}
         promos
     }
 }`
@@ -321,12 +321,13 @@ mutation {
     )
 }`
 
-const setLineupDjLiveMutation = (lineup_name, dj_name, is_live) => `
+const updateLineupDjMutation = (lineup_name, dj_name, is_live, vj) => `
 mutation {
     setLineupDjLive(
         lineup_name: "${lineup_name}",
         dj_name: "${dj_name}",
-        is_live: ${is_live}
+        is_live: ${is_live},
+        vj: "${vj}"
     )
 }`
 
@@ -575,8 +576,8 @@ export function fetchAddDjToLineup(lineup_name, dj_name) {
     });
 }
 
-export function fetchUpdateLineupDj(lineup_name, dj_name, is_live) {
-    return fetch(setLineupDjLiveMutation(lineup_name, dj_name, is_live)).then(promise => {
+export function fetchUpdateLineupDj(lineup_name, dj_name, is_live, vj) {
+    return fetch(updateLineupDjMutation(lineup_name, dj_name, is_live, vj)).then(promise => {
         Promise.resolve(promise).then(response => {
 			if (response.hasOwnProperty("errors")) {
                 errorStackPushHelper(response.errors[0]);

--- a/Web Version/shizu-frontend/src/shared/DjLineupModal.svelte
+++ b/Web Version/shizu-frontend/src/shared/DjLineupModal.svelte
@@ -1,7 +1,8 @@
 <script>
     import {
         IconButton,
-        MaterialSelect
+        MaterialSelect,
+        MaterialInput
     } from 'linkcube-svelte-components';
     import Modal from './Modal.svelte';
     import { 
@@ -19,6 +20,7 @@
     export let current_lineup = "";
     export let name = "";
     export let is_live = false;
+    export let vj = "";
 
     const dispatch = createEventDispatcher();
     const close = () => dispatch('close');
@@ -26,7 +28,8 @@
     const rtmp_conversion = {
         "us-west": "US West",
         "us-east": "US East",
-        "japan": "Japan"
+        "jp": "Japan",
+        "europe": "Europe"
     };
     let logo_name = "";
     let recording_name = "";
@@ -63,7 +66,7 @@
     }
 
     export const saveDj = () => {
-        fetchUpdateLineupDj(current_lineup, dj_data.name, is_live).then(_ => fetchLineup(current_lineup));
+        fetchUpdateLineupDj(current_lineup, dj_data.name, is_live, vj).then(_ => fetchLineup(current_lineup));
         close();
     }
 </script>
@@ -111,6 +114,9 @@
                     <option value={false}>False</option>
                     <option value={true}>True</option>
                 </MaterialSelect>
+            </div>
+            <div class="row">
+                <MaterialInput label="VJ Name" bind:value={vj}/>
             </div>
         </div>
     </Modal>

--- a/Web Version/shizu-frontend/src/shared/LineupsTable.svelte
+++ b/Web Version/shizu-frontend/src/shared/LineupsTable.svelte
@@ -48,6 +48,7 @@
     let edit_dj_index = 0;
     let edit_dj_name = "";
     let edit_dj_is_live = false;
+    let edit_dj_vj = "";
     let show_edit_dj = false;
 
     let edit_promo_index = 0;
@@ -112,12 +113,13 @@
 		current_lineup = null;
 	}
 
-    const editDj = (index, name, is_live) => {
+    const editDj = (index, name, is_live, vj) => {
         show_export_error = true;
         last_action = EDIT_DJ_FAILED;
         edit_dj_index = index;
         edit_dj_name = name;
         edit_dj_is_live = is_live;
+        edit_dj_vj = vj;
         show_edit_dj = true;
     }
 
@@ -315,6 +317,7 @@
         name={edit_dj_name}
         is_live={edit_dj_is_live}
         current_lineup={current_lineup}
+        vj={edit_dj_vj}
         on:close={() => show_edit_dj = false}
     />
 {/if}
@@ -378,7 +381,7 @@
                         <NewMatTableRow
                             values={[`${index + 1}`, item.name, item.is_live]}
                             type="click row draggable"
-                            on:click={() => editDj(index, item.name, item.is_live)}
+                            on:click={() => editDj(index, item.name, item.is_live, item.vj)}
                             on:dragstart={() => handleDragStart(index)}
                             on:dragover={() => handleDragOver(index)}
                             on:dragend={() => handleDjDragEnd()}

--- a/obs_hijack_script.py
+++ b/obs_hijack_script.py
@@ -54,6 +54,7 @@ class Hijack:
         # Initialize djs->promos scenes in memory
         lineup_scenes = []
         for dj_entry in lineup_data[DJ_KEY]:
+            print(dj_entry)
             dj_scene = ObsSceneValue(
                 dj_entry.get("name"),
                 True,
@@ -66,6 +67,7 @@ class Hijack:
                 dj_scene.stream_url = dj_entry.get("url")
             else:
                 dj_scene.recording_path = dj_entry.get("recording_path")
+            dj_scene.vj = dj_entry.get("vj")
             lineup_scenes.append(dj_scene)
         promos = []
         for promo in lineup_data[PROMO_KEY]:
@@ -190,6 +192,36 @@ class Hijack:
 
             S.obs_data_release(text_settings)
             S.obs_source_release(text_source)
+    
+        # Setup VJ
+        if scene_values.vj:
+            text_source_name = f"{scene_values.name}_vj"
+            text_settings = S.obs_data_create()
+            S.obs_data_set_string(text_settings, "text", "VJ: " + scene_values.vj)
+            font_data_obj = S.obs_data_create_from_json(json.dumps({"face":"Arial","style":"Regular","size":200,"flags":0}))
+            S.obs_data_set_obj(text_settings, "font", font_data_obj)
+            text_source = S.obs_source_create("text_gdiplus", text_source_name, text_settings, None)
+            text_item = S.obs_scene_add(scene, text_source)
+
+            # From OBS c obs-defs.h
+            align_right = 1 << 1
+            align_bottom = 1 << 3
+
+            alignment = align_right | align_bottom
+            S.obs_sceneitem_set_alignment(text_item, alignment)
+
+            pos = S.vec2()
+            pos.x = self.render_width
+            pos.y = self.render_height
+            S.obs_sceneitem_set_pos(text_item, pos)
+
+            scale = S.vec2()
+            scale.x = 1
+            scale.y = 1
+            S.obs_sceneitem_set_scale(text_item, scale)
+
+            S.obs_data_release(text_settings)
+            S.obs_source_release(text_source)
 
 
     def setup_promo_scene_items(self, scene, promotion: 'ObsPromoScene'):
@@ -222,6 +254,7 @@ class ObsSceneValue:
     recording_path = None
     stream_url = None
     resolution = None
+    vj = None
 
     def __init__(self, name, is_dj, logo_path, recording_path, stream_url, resolution):
         self.name = name
@@ -232,7 +265,7 @@ class ObsSceneValue:
         self.resolution = resolution
     
     def __str__(self) -> str:
-        return f"Name: {self.name}, is_dj: {self.is_dj}, logo: {self.logo_path}, rec: {self.recording_path}, url: {self.stream_url}"
+        return f"Name: {self.name}, is_dj: {self.is_dj}, logo: {self.logo_path}, rec: {self.recording_path}, url: {self.stream_url}, vj: {self.vj}"
 
 class ObsPromoScene(ObsSceneValue):
     def __init__(self, paths):


### PR DESCRIPTION
Adds a field to lineup DJs for an optional VJ name, set distinctions on what backend args are optional.
Fixed an issue that preventing updating DJs/Promos without a name change.
Updated the OBS script to use the exported VJ value to generate an additional text element.